### PR TITLE
Handling of undefined response key

### DIFF
--- a/codable.lisp
+++ b/codable.lisp
@@ -21,7 +21,6 @@
                 #:alist-hash-table
                 #:ensure-list)
   (:export #:undefined-key
-           #:ignore-key
            #:codable
            #:codable-class
            #:decode-object
@@ -156,7 +155,7 @@
                                                       :name key
                                                       :value val
                                                       :class class)
-                                   (ignore-key ()
+                                   (continue ()
                                      :report "Ignore key"
                                      nil)))))
     (apply #'make-instance class initargs)))


### PR DESCRIPTION
If a key is added to the response of the API of the web service I are using, an error occurs during parsing in the current situation.
To address this issue, I have added a restart option in the event of an error.

For example, use the following
```common-lisp
(handler-bind ((webapi/codable:undefined-key #'continue))
  (webapi:send (make-instance 'search-repositories :q "Common Lisp")))
```